### PR TITLE
feat: Update CrowdNode URLs to dashnode proxy

### DIFF
--- a/src/components/GetCrowdNodeBalance.vue
+++ b/src/components/GetCrowdNodeBalance.vue
@@ -3,11 +3,13 @@ import { ref, watch, inject, } from 'vue'
 import * as CrowdNode from 'crowdnode'
 
 const DASHSIGHT_BASE_URL = inject('DASHSIGHT_BASE_URL')
+const CROWDNODE_BASE_URL = inject('CROWDNODE_BASE_URL')
+const CROWDNODE_KB_URL = inject('CROWDNODE_KB_URL')
 
 CrowdNode.init({
-    baseUrl: '/crowdnode',
+    baseUrl: CROWDNODE_BASE_URL,
     insightBaseUrl: DASHSIGHT_BASE_URL,
-    knowledgeBaseUrl: '/knowledge'
+    knowledgeBaseUrl: CROWDNODE_KB_URL,
 });
 
 async function getCrowdNodeBalances() {

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,8 @@ import App from './App.vue'
 const app = createApp(App)
 
 app.provide('DASHSIGHT_BASE_URL', import.meta.env.INSIGHT_BASE_URL || 'https://insight.dash.org')
+app.provide('CROWDNODE_BASE_URL', import.meta.env.CROWDNODE_BASE_URL || 'https://dashnode.duckdns.org/api/cors/app.crowdnode.io')
+app.provide('CROWDNODE_KB_URL', import.meta.env.CROWDNODE_KB_URL || 'https://dashnode.duckdns.org/api/cors/knowledge.crowdnode.io')
 app.provide('DASH_ADDR_LENGTH', 34)
 // Pulled from https://github.com/dashhive/dashsight.js/blob/main/examples/addrs.txt
 app.provide('testAddresses', 'XmaroZwvCKjsYQQVdCQP2BuWnnMGxWLCGJ XmCyQ6qARLWXap74QubFMunngoiiA1QgCL XaxrcNUS6MrAfsvXNF2s24eChFVKabU6gP XdaWS6gScUjxbFdA8WSFZbeBK2mpGDr6uc XgfQUxiwo7BnTpwxAqpmVJSJwtJHdRCJd2 Xhn6eTCwW94vhVifhshyTeihvTa7LcatiM XnepcKMViJE3bR4ggFkAfLGgqBSr6EjA8z Xp3pqfnYUYLif4SqWFU3Fuv4hJJQRen1ud Xsa1WM9FbRxqSfBxjfFVjLfQ5zinK5NHio Xw2zuXP3VwoRKMoV7cA9TQpJ5bnbCsw13Q XxrK9XH5L3mGCyirz26RpGpCQcJB3v39Lk'

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,26 +6,6 @@ import basicSsl from '@vitejs/plugin-basic-ssl'
 export default defineConfig({
   server: {
     https: true,
-    proxy: {
-      "/insight": {
-        target: "https://insight.dash.org",
-        changeOrigin: true,
-        secure: false,
-        rewrite: (path) => path.replace(/^\/insight/, ""),
-      },
-      "/crowdnode": {
-        target: "https://app.crowdnode.io",
-        changeOrigin: true,
-        secure: false,
-        rewrite: (path) => path.replace(/^\/crowdnode/, ""),
-      },
-      "/knowledge": {
-        target: "https://knowledge.crowdnode.io",
-        changeOrigin: true,
-        secure: false,
-        rewrite: (path) => path.replace(/^\/knowledge/, ""),
-      },
-    },
   },
   plugins: [
     basicSsl(),


### PR DESCRIPTION
This uses the new https://dashnode.duckdns.org/api/cors/ proxy for CrowdNode access